### PR TITLE
Ensure event independence across paths

### DIFF
--- a/engine/batch_runner.py
+++ b/engine/batch_runner.py
@@ -83,6 +83,9 @@ class BatchRunner:
         fired_counts  = {}
 
         for i in range(self.n_paths):
+            # Reset event engine state so events don't bleed across paths
+            self.et.reset()
+
             # Per-path initializations
             timeline = self.ts.sample_timeline()
             bucket_counts[timeline["bucket"]] += 1

--- a/engine/event_tree_engine.py
+++ b/engine/event_tree_engine.py
@@ -45,6 +45,14 @@ class EventTreeEngine:
         # NEW: Load event_stats.json and create the map
         self.event_stats_map = self._load_event_stats_map()
 
+        # Initialize per-run state
+        self.reset()
+
+    def reset(self) -> None:
+        """Clear state so events are evaluated independently."""
+        self._fired_events_history: set[str] = set()
+        self.triggered_ep3_event_id = None
+
     def _load_events(self, events_path: str | Path) -> List[Event]:
         """Loads events from a JSON file."""
         with open(events_path, "r") as f:


### PR DESCRIPTION
## Summary
- add a `reset()` method to `EventTreeEngine`
- clear fired-event history and EP3 state before each path in `BatchRunner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cc1f06ec832c92ba73623a0fb503